### PR TITLE
feature(endpoint): make api endpoint restful Finishes #149304069

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -99,3 +99,4 @@ facebook-config-ui
 google-config-ui
 twitter-config-ui
 dynamic-import
+simple:rest

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -153,6 +153,8 @@ service-configuration@1.0.11
 session@1.1.7
 sha@1.0.9
 shell-server@0.2.4
+simple:json-routes@2.1.0
+simple:rest@1.1.1
 spacebars@1.0.15
 spacebars-compiler@1.1.2
 srp@1.0.10

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -1,4 +1,5 @@
 import url from "url";
+import { Random } from "meteor/random";
 import { Meteor } from "meteor/meteor";
 import { FlowRouter } from "meteor/kadira:flow-router-ssr";
 import { Shops } from "/lib/collections";
@@ -7,9 +8,7 @@ import { Shops } from "/lib/collections";
 //
 //  TODO review this slugify import in lib/api/helpers
 //
-if (Meteor.isServer) {
-  import { slugify } from "transliteration";
-}
+import { slugify } from "transliteration";
 
 /**
  * getShopId

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "swiper": "^3.3.1",
     "tether-drop": "^1.4.2",
     "tether-tooltip": "^1.2.0",
-    "transliteration": "^1.1.9",
+    "transliteration": "github:reactioncommerce/transliteration",
+    "twilio": "^3.6.2",
     "url": "^0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
#### What does this PR do?
    Make the API endpoints RESTful by extending Meteor DDP methods.
#### Description of Task to be completed?
    - Extend Meteor DDP methods and provide restful API.
    - As a user I should be able to make a request to RESTful Api’s endpoint.
#### How should this be manually tested?
Using `postman` to test the endpoints
* `GET http://localhost:3000/publications/Products`
#### Any background context you want to provide?
    N/A
#### What are the relevant pivotal tracker stories?
    Make API endpoints RESTful
#### Screenshots (if appropriate)

<img width="1279" alt="screen shot 2017-08-15 at 7 12 35 am" src="https://user-images.githubusercontent.com/14937533/29308263-0e92ff20-819d-11e7-88a6-e285e0ae8a38.png">
![localhost-3000-publications-products](https://user-images.githubusercontent.com/14937533/29308271-1e1cd1be-819d-11e7-9dbe-11831dfeb5b6.png)

#### Questions:
    N/A