### PR TITLE
feature(search): Display real time search result on typing

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -99,3 +99,4 @@ facebook-config-ui
 google-config-ui
 twitter-config-ui
 dynamic-import
+mizzao:autocomplete

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -57,6 +57,7 @@ cfs:worker@0.1.4
 check@1.2.5
 chuangbo:cookie@1.1.0
 coffeescript@1.12.6_1
+dandv:caret-position@2.1.1
 dburles:factory@1.1.0
 ddp@1.3.0
 ddp-client@2.0.0
@@ -115,6 +116,8 @@ meteorhacks:ssr@2.2.0
 meteorhacks:subs-manager@1.6.4
 minifier-css@1.2.16
 minimongo@1.2.1
+mizzao:autocomplete@0.5.1
+minimongo@1.0.23
 mobile-experience@1.0.4
 mobile-status-bar@1.0.14
 modules@0.9.2

--- a/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
+++ b/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
@@ -7,7 +7,7 @@
       {{> tagNav tagNavProps}}
     </div>
     <div class="menu"><a href="/reaction/about">{{> React pageButton}}</a></div>
-    <div class="search">{{> React IconButtonComponent}}</div>
+    <div class="search search-test">{{> React IconButtonComponent}}</div>
     <div class="languages hidden-xs">{{> i18nChooser}}</div>
     <div class="accounts">{{> accounts tpl="loginDropdown"}}</div>
     <div class="cart">{{> cartIcon}}</div>

--- a/imports/plugins/included/default-theme/client/styles/search/search-type-toggle.less
+++ b/imports/plugins/included/default-theme/client/styles/search/search-type-toggle.less
@@ -25,3 +25,7 @@
 
   }
 }
+-autocomplete-container {
+  font-size: 18px;
+  margin-top: 25px;
+ }

--- a/imports/plugins/included/search-mongo/server/publications/searchresults.js
+++ b/imports/plugins/included/search-mongo/server/publications/searchresults.js
@@ -9,11 +9,26 @@ const supportedCollections = ["products", "orders", "accounts"];
 function getProductFindTerm(searchTerm, searchTags, userId) {
   const shopId = Reaction.getShopId();
   const findTerm = {
-    shopId: shopId,
-    $text: {$search: searchTerm}
+    $and: [
+      { shopId: shopId },
+      { $or: [
+        {
+          title: {
+            $regex: searchTerm,
+            $options: "i"
+          }
+        },
+        {
+          description: {
+            $regex: searchTerm,
+            $options: "i"
+          }
+        }
+      ] }
+    ]
   };
   if (searchTags.length) {
-    findTerm.hashtags = {$all: searchTags};
+    findTerm.hashtags = { $all: searchTags };
   }
   if (!Roles.userIsInRole(userId, ["admin", "owner"], shopId)) {
     findTerm.isVisible = true;
@@ -29,14 +44,17 @@ getResults.products = function (searchTerm, facets, maxResults, userId) {
   const productResults = ProductSearch.find(findTerm,
     {
       fields: {
-        score: {$meta: "textScore"},
+        score: { $meta: "textScore" },
         title: 1,
         hashtags: 1,
         description: 1,
         handle: 1,
-        price: 1
+        price: 1,
+        isSoldOut: 1,
+        isLowQuantity: 1,
+        isBackorder: 1
       },
-      sort: {score: {$meta: "textScore"}},
+      sort: { score: { $meta: "textScore" } },
       limit: maxResults
     }
   );
@@ -50,7 +68,7 @@ getResults.orders = function (searchTerm, facets, maxResults, userId) {
   const findTerm = {
     $and: [
       { shopId: shopId },
-      {$or: [
+      { $or: [
         { _id: searchTerm },
         { userEmails: {
           $regex: searchTerm,
@@ -73,7 +91,7 @@ getResults.orders = function (searchTerm, facets, maxResults, userId) {
           $options: "i"
         } }
       ] }
-    ]};
+    ] };
   if (Reaction.hasPermission("orders", userId)) {
     orderResults = OrderSearch.find(findTerm, { limit: maxResults });
     Logger.debug(`Found ${orderResults.count()} orders searching for ${searchTerm}`);
@@ -88,8 +106,8 @@ getResults.accounts = function (searchTerm, facets, maxResults, userId) {
   if (Reaction.hasPermission("reaction-accounts", userId)) {
     const findTerm = {
       $and: [
-        {shopId: shopId},
-        {$or: [
+        { shopId: shopId },
+        { $or: [
           { emails: {
             $regex: searchTerm,
             $options: "i"
@@ -107,7 +125,7 @@ getResults.accounts = function (searchTerm, facets, maxResults, userId) {
             $options: "i"
           } }
         ] }
-      ]};
+      ] };
     accountResults = AccountSearch.find(findTerm, {
       limit: maxResults
     });

--- a/imports/plugins/included/ui-search/client/index.js
+++ b/imports/plugins/included/ui-search/client/index.js
@@ -2,6 +2,7 @@
 import "./templates/searchModal/searchModal.html";
 import "./templates/searchModal/searchModal.js";
 import "./templates/searchModal/searchInput.html";
+import "./templates/searchModal/searchInput.js";
 import "./templates/searchModal/searchTypeToggle.html";
 import "./templates/searchModal/searchResults.html";
 

--- a/imports/plugins/included/ui-search/client/templates/productSearch/content.html
+++ b/imports/plugins/included/ui-search/client/templates/productSearch/content.html
@@ -2,7 +2,7 @@
   <div class="grid-content">
     <a href="{{pathFor 'product' handle=product.handle}}" data-event-category="grid" data-event-action="productClick" data-event-label="grid product click" data-event-value="{{product._id}}">
       <div class="overlay">
-        <div class="overlay-title">{{product.title}}</div>
+        <div class="overlay-title" id="suggestedTitle">{{product.title}}</div>
         <div class="currency-symbol">{{formatPrice product.price.range}}</div>
         <div class="overlay-description">{{product.description}}</div>
       </div>

--- a/imports/plugins/included/ui-search/client/templates/searchModal/searchInput.html
+++ b/imports/plugins/included/ui-search/client/templates/searchModal/searchInput.html
@@ -2,7 +2,13 @@
   <div class="rui search-modal-input">
     <label for="search-input" data-i18n="search.searchInputLabel">Search {{siteName}}</label>
     <i class="fa fa-search search-icon"></i>
-    <input type="text" id="search-input" />
+    {{> inputAutocomplete settings=settings id="search-input"}}
     <span class="search-clear" data-event-action="clearSearch"  data-i18n="search.clearSearch">Clear</span>
   </div>
+</template>
+<template name="searchResult">
+  <span class="label" style="color: #000; font-size: 12px">{{title}}</span>
+</template>
+<template name="noResult">
+  <span class="label" style="color: #000; font-size: 12px"> Oops! No match found. Try a different search or look at the description of the displayed products </span>
 </template>

--- a/imports/plugins/included/ui-search/client/templates/searchModal/searchInput.js
+++ b/imports/plugins/included/ui-search/client/templates/searchModal/searchInput.js
@@ -1,0 +1,23 @@
+import { Template } from "meteor/templating";
+import { ProductSearch } from "/lib/collections";
+
+Template.searchInput.helpers({
+  settings: function () {
+    return {
+      position: "bottom",
+      limit: 4,
+      rules: [
+        {
+          token: "",
+          collection: ProductSearch,
+          field: "title",
+          options: "i",
+          sort: true,
+          matchAll: true,
+          template: Template.searchResult,
+          noMatchTemplate: Template.noResult
+        }
+      ]
+    };
+  }
+});

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -7,9 +7,9 @@ import { Shops } from "/lib/collections";
 //
 //  TODO review this slugify import in lib/api/helpers
 //
-if (Meteor.isServer) {
-  import { slugify } from "transliteration";
-}
+
+import { slugify } from "transliteration";
+
 
 /**
  * getShopId

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "swiper": "^3.3.1",
     "tether-drop": "^1.4.2",
     "tether-tooltip": "^1.2.0",
-    "transliteration": "^1.1.9",
+    "transliteration": "github:reactioncommerce/transliteration",
     "url": "^0.11.0"
   },
   "devDependencies": {

--- a/tests/acceptance-tests/config/user-data.yml
+++ b/tests/acceptance-tests/config/user-data.yml
@@ -1,6 +1,6 @@
-admin_user: Administrator
-admin_email: testing@reactioncommerce.com
-admin_pw: password123
+admin_user: Admin
+admin_email: u3mxjmqx@localhost
+admin_pw: scgsqYPb
 
 guest_email: "guest@reactioncommerce.com"
 guest_pw: password123

--- a/tests/acceptance-tests/elements/element-ids.yml
+++ b/tests/acceptance-tests/elements/element-ids.yml
@@ -1,3 +1,4 @@
 login_dropdown: Sign In
 login_email_fld_id: email
 login_pw_fld_id: password
+search_input_id: search-input

--- a/tests/acceptance-tests/elements/element-map.yml
+++ b/tests/acceptance-tests/elements/element-map.yml
@@ -1,5 +1,6 @@
 login_dropdown_btn: "[data-event-action='accounts-dropdown-click']"
 login_email_fld: "[class='form-control login-input-email']"
+search_test: "[class='search search-test']"
 login_pw_fld: "[class='form-control login-input-password']"
 login_btn: "[data-event-action='submitSignInForm']"
 

--- a/tests/acceptance-tests/test/specs/smoke-tests/search-app-test.js
+++ b/tests/acceptance-tests/test/specs/smoke-tests/search-app-test.js
@@ -1,0 +1,35 @@
+"use strict";
+const yaml = require("js-yaml");
+const fs   = require("fs");
+const expect = require("chai").expect;
+
+beforeEach(function () {
+  const browserConfig = yaml.safeLoad(fs.readFileSync("./tests/acceptance-tests/config/settings.yml", "utf8"));
+  const baseUrl = browserConfig.base_url.toString();
+  browser.url(baseUrl);
+});
+
+describe("Real Time Search", function () {
+  it("should display all products that meet the search criteria", function () {
+    const eleMap = yaml.safeLoad(fs.readFileSync("./tests/acceptance-tests/elements/element-map.yml", "utf8"));
+    const inputText = "e";
+
+    browser.pause("5000");
+    browser.click(eleMap.search_test);
+    browser.pause(5000);
+    browser.setValue("#search-input", inputText);
+    browser.pause(5000);
+    expect(browser.getText("#suggestedTitle")).to.contain("BASIC REACTION PRODUCT");
+  });
+  it("should display all products that meet the search criteria", function () {
+    const eleMap = yaml.safeLoad(fs.readFileSync("./tests/acceptance-tests/elements/element-map.yml", "utf8"));
+    const inputText = "ba";
+
+    browser.pause("5000");
+    browser.click(eleMap.search_test);
+    browser.pause(5000);
+    browser.setValue("#search-input", inputText);
+    browser.pause(5000);
+    expect(browser.getText("#suggestedTitle")).to.contain("BASIC REACTION PRODUCT");
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

It implements the feature "Display real-time results as shopper is typing"
#### Description of Task to be completed?

Similar to a google search, display relevant results on the page as a user is typing rather than wait until they submit the search.
How should this be manually tested?

Login and type what you want to search for in the text area provided which appears after you click on the search icon. The results would be displayed as seen in the screenshots below.
#### Any background context you want to provide?

N/A
#### What are the relevant pivotal tracker stories?

#149304077 Display real-time results as shopper is typing

#### Screenshots (if appropriate)

<img width="855" alt="screen shot 2017-08-17 at 5 11 42 pm" src="https://user-images.githubusercontent.com/28534124/29422317-bde9839e-836f-11e7-833c-a46271ff6d7b.png">


run the test using the command 

```npm run test-local```

<img width="846" alt="screen shot 2017-08-17 at 5 08 08 pm" src="https://user-images.githubusercontent.com/28534124/29422056-e5d626a6-836e-11e7-8de0-2828987fad5f.png">

#### Any Questions?
No questions available

